### PR TITLE
Add additional language support

### DIFF
--- a/spawn_juicer.ahk
+++ b/spawn_juicer.ahk
@@ -26,7 +26,7 @@ global f3showDelay = 100 ; how many milliseconds of delay before showing f3. If 
 global logging = False ; turn this to True to generate logs in macro_logs.txt and DebugView; don't keep this on True because it'll slow things down
 global kryptonChecker := True ; change this to False if you want to use Krypton (highly recommend not using Krypton as it will usually break the macro)
 global coop := False ; will automatically open to LAN and prepare "/time set 0" (without sending command) when you join a world
-global language := "English" ; *EXPERIMENTAL* changes what title string is looked for based on set language. Will close the script if not set correctly.
+global language := "English" ; Experimental, default English. Changes what title string is looked for based on set language. Will close the script if not set correctly.
 ; Current language support: English, LOLCAT, Shakespearean English, 日本語, Bosanski, Nederlands
 
 ; Autoresetter Options:

--- a/spawn_juicer.ahk
+++ b/spawn_juicer.ahk
@@ -26,6 +26,8 @@ global f3showDelay = 100 ; how many milliseconds of delay before showing f3. If 
 global logging = False ; turn this to True to generate logs in macro_logs.txt and DebugView; don't keep this on True because it'll slow things down
 global kryptonChecker := True ; change this to False if you want to use Krypton (highly recommend not using Krypton as it will usually break the macro)
 global coop := False ; will automatically open to LAN and prepare "/time set 0" (without sending command) when you join a world
+global language := "English" ; *EXPERIMENTAL* changes what title string is looked for based on set language. Will close the script if not set correctly.
+; Current language support: English, LOLCAT, Shakespearean English, 日本語, Bosanski, Nederlands
 
 ; Autoresetter Options:
 ; The autoresetter will automatically reset if your spawn is greater than a certain number of blocks away from a certain point (ignoring y)
@@ -566,8 +568,39 @@ GetActiveInstanceNum() {
 return -1
 }
 
-IsInGame(currTitle) { ; If using another language, change Singleplayer and Multiplayer to match game title
-return InStr(currTitle, "Singleplayer") || InStr(currTitle, "Multiplayer") || InStr(currTitle, "Instance")
+IsInGame(currTitle) { ; Checks game title against language selected
+
+if(language == "English") {
+  return InStr(currTitle, "Singleplayer") || InStr(currTitle, "Multiplayer") || InStr(currTitle, "Instance")
+}
+
+else if(language == "LOLCAT"){
+  return InStr(currTitle, "Loneleh kitteh") || InStr(currTitle, "NAT LONELEY") || InStr(currTitle, "Instance")
+}
+
+else if(language == "Shakespearean English") {
+  return InStr(currTitle, "Soliloquy") || InStr(currTitle, "Multiplay'r") || InStr(currTitle, "Instance")
+}
+
+else if(language == "Japanese" or language == "日本語") {
+  return InStr(currTitle, "シングルプレイ") || InStr(currTitle, "マルチプレイ") || InStr(currTitle, "Instance")
+}
+
+else if(language == "Bosanski" or language == "Bosnian" or language == "босански"){
+  return InStr(currTitle, "Samostalna igra") || InStr(currTitle, "Mrežna igra") || InStr(currTitle, "Instance")
+}
+
+else if(language == "Dutch" or language == "Nederlands") {
+  return InStr(currTitle, "Alleen spelen") || InStr(currTitle, "Samen spelen") || InStr(currTitle, "Instance")
+}
+
+;add more here, replace this line
+
+else {
+  MsgBox, Language set incorrectly or not supported yet, please change it and restart script
+  ExitApp
+}
+
 }
 
 Reset(state := 0)

--- a/spawn_juicer.ahk
+++ b/spawn_juicer.ahk
@@ -26,8 +26,6 @@ global f3showDelay = 100 ; how many milliseconds of delay before showing f3. If 
 global logging = False ; turn this to True to generate logs in macro_logs.txt and DebugView; don't keep this on True because it'll slow things down
 global kryptonChecker := True ; change this to False if you want to use Krypton (highly recommend not using Krypton as it will usually break the macro)
 global coop := False ; will automatically open to LAN and prepare "/time set 0" (without sending command) when you join a world
-global language := "English" ; Experimental, default English. Changes what title string is looked for based on set language. Will close the script if not set correctly.
-; Current language support: English, LOLCAT, Shakespearean English, 日本語, Bosanski, Nederlands
 
 ; Autoresetter Options:
 ; The autoresetter will automatically reset if your spawn is greater than a certain number of blocks away from a certain point (ignoring y)
@@ -89,6 +87,7 @@ for i, tmppid in PIDs{
   WinSet, AlwaysOnTop, Off, ahk_pid %tmppid%
 }
 global version = getVersion()
+global language := readLine("lang", 1)
 
 for k, saves_directory in SavesDirectories
 {
@@ -568,36 +567,163 @@ GetActiveInstanceNum() {
 return -1
 }
 
-IsInGame(currTitle) { ; Checks game title against language selected
+IsInGame(currTitle) { ; Checks game title against language in options
 
-if(language == "English") {
-  return InStr(currTitle, "Singleplayer") || InStr(currTitle, "Multiplayer") || InStr(currTitle, "Instance")
+if(language == "ar_sa"){
+  return InStr(currTitle, "اللعب الفردي") || InStr(currTitle, "متعدد اللاعبين") || InStr(currTitle, "Instance")
 }
 
-else if(language == "LOLCAT"){
-  return InStr(currTitle, "Loneleh kitteh") || InStr(currTitle, "NAT LONELEY") || InStr(currTitle, "Instance")
-}
-
-else if(language == "Shakespearean English") {
-  return InStr(currTitle, "Soliloquy") || InStr(currTitle, "Multiplay'r") || InStr(currTitle, "Instance")
-}
-
-else if(language == "Japanese" or language == "日本語") {
-  return InStr(currTitle, "シングルプレイ") || InStr(currTitle, "マルチプレイ") || InStr(currTitle, "Instance")
-}
-
-else if(language == "Bosanski" or language == "Bosnian" or language == "босански"){
+else if(language == "bs_ba"){
   return InStr(currTitle, "Samostalna igra") || InStr(currTitle, "Mrežna igra") || InStr(currTitle, "Instance")
 }
 
-else if(language == "Dutch" or language == "Nederlands") {
+else if(language == "de_ch" or language == "de_de"){
+  return InStr(currTitle, "Einzelspieler") || InStr(currTitle, "Mehrspieler") || InStr(currTitle, "Instance")
+}
+
+else if(language == "el_gr"){
+  return InStr(currTitle, "Παιχνίδι Ενός Παίκτη") || InStr(currTitle, "Παιχνίδι Πολλαπλών Παικτών") || InStr(currTitle, "Instance")
+}
+
+else if(language == "en_au" or language == "en_ca" or language == "en_gb" or language == "en_nz" or language == "en_us"){
+  return InStr(currTitle, "Singleplayer") || InStr(currTitle, "Multiplayer") || InStr(currTitle, "Instance")
+}
+
+else if(language == "en_pt"){
+  return InStr(currTitle, "Lonely voyage") || InStr(currTitle, "Playing with yer mates") || InStr(currTitle, "Instance")
+}
+
+else if(language == "en_ud"){
+  return InStr(currTitle, "ɹǝʎɐꞁdǝꞁᵷuᴉS") || InStr(currTitle, "ɹǝʎɐꞁdᴉʇꞁnW") || InStr(currTitle, "Instance")
+}
+
+else if(language == "enp"){
+  return InStr(currTitle, "Oneplayer") || InStr(currTitle, "Maniplayer") || InStr(currTitle, "Instance")
+}
+
+else if(language == "enws"){
+  return InStr(currTitle, "Soliloquy") || InStr(currTitle, "Multiplay'r") || InStr(currTitle, "Instance")
+}
+
+else if(language == "eo_uy"){
+  return InStr(currTitle, "Unu ludanto") || InStr(currTitle, "Pluraj ludantoj") || InStr(currTitle, "Instance")
+}
+
+else if(language == "es_cl" or language == "es_ec" or language == "es_es" or language == "es_mx" or language == "es_uy" or language == "es_ve" or language == "es_ar"){
+  return InStr(currTitle, "Un jugador") || InStr(currTitle, "Multijugador") || InStr(currTitle, "Instance")
+}
+
+else if(language == "fi_fi"){
+  return InStr(currTitle, "Yksinpeli") || InStr(currTitle, "Moninpeli") || InStr(currTitle, "Instance")
+}
+
+else if(language == "fil_ph"){
+  return InStr(currTitle, "Pang-isahang Laro") || InStr(currTitle, "Pang-maramihang Laro") || InStr(currTitle, "Instance")
+}
+
+else if(language == "fr_ca" or language == "fr_fr"){
+  return InStr(currTitle, "Solo") || InStr(currTitle, "Multijoueur") || InStr(currTitle, "Instance")
+}
+
+else if(language == "fy_nl"){
+  return InStr(currTitle, "Allinnich spylje") || InStr(currTitle, "Tegearre spylje") || InStr(currTitle, "Instance")
+}
+
+else if(language == "haw_us"){
+  return InStr(currTitle, "Paʻani wale") || InStr(currTitle, "Multiplayer") || InStr(currTitle, "Instance")
+}
+
+else if(language == "he_il"){
+  return InStr(currTitle, "שחקן יחיד") || InStr(currTitle, "רב-משתתפים") || InStr(currTitle, "Instance")
+}
+
+else if(language == "hi_in"){
+  return InStr(currTitle, "बहुखिलाड़ी") || InStr(currTitle, "एकलखिलाड़ी") || InStr(currTitle, "Instance")
+}
+
+else if(language == "id_id"){
+  return InStr(currTitle, "Bermain Sendiri") || InStr(currTitle, "Bermain Bersama") || InStr(currTitle, "Instance")
+}
+
+else if(language == "is_is"){
+  return InStr(currTitle, "Spila einn") || InStr(currTitle, "Netspilun") || InStr(currTitle, "Instance")
+}
+
+else if(language == "it_it"){
+  return InStr(currTitle, "Giocatore singolo") || InStr(currTitle, "Multigiocatore") || InStr(currTitle, "Instance")
+}
+
+else if(language == "ja_jp"){
+  return InStr(currTitle, "シングルプレイ") || InStr(currTitle, "マルチプレイ") || InStr(currTitle, "Instance")
+}
+
+else if(language == "ko_kr"){
+  return InStr(currTitle, "싱글플레이") || InStr(currTitle, "멀티플레이") || InStr(currTitle, "Instance")
+}
+
+else if(language == "la_la"){
+  return InStr(currTitle, "Ludus unius") || InStr(currTitle, "Ludus multorum") || InStr(currTitle, "Instance")
+}
+
+else if(language == "lol_us"){
+  return InStr(currTitle, "Loneleh Kitteh") || InStr(currTitle, "Multiplayr") || InStr(currTitle, "Instance")
+}
+; is different in non-lan multiplayer
+
+else if(language == "lzh"){
+  return InStr(currTitle, "獨戲") || InStr(currTitle, "衆戲") || InStr(currTitle, "Instance")
+}
+
+else if(language == "nl_nl"){
   return InStr(currTitle, "Alleen spelen") || InStr(currTitle, "Samen spelen") || InStr(currTitle, "Instance")
 }
 
-;add more here, replace this line
+else if(language == "nn_no"){
+  return InStr(currTitle, "Einspelar") || InStr(currTitle, "Fleirspelar") || InStr(currTitle, "Instance")
+}
+
+else if(language == "pl_pl"){
+  return InStr(currTitle, "Tryb jednoosobowy") || InStr(currTitle, "Gra wieloosobowa") || InStr(currTitle, "Instance")
+}
+
+else if(language == "pt_br" or language == "pt_pt"){
+  return InStr(currTitle, "Um jogador") || InStr(currTitle, "Multijogador") || InStr(currTitle, "Instance")
+}
+
+else if(language == "sl_si"){
+  return InStr(currTitle, "Enoigralski način") || InStr(currTitle, "Večigralski način") || InStr(currTitle, "Instance")
+}
+
+else if(language == "sv_se"){
+  return InStr(currTitle, "Enspelarläge") || InStr(currTitle, "Flerspelarläge") || InStr(currTitle, "Instance")
+}
+
+else if(language == "tl_ph"){
+  return InStr(currTitle, "Pang-isahang Laro") || InStr(currTitle, "Pang-maramihang Laro") || InStr(currTitle, "Instance")
+}
+
+else if(language == "tok"){
+  return InStr(currTitle, "musi pi jan wan") || InStr(currTitle, "ma kulupu pi jan poka") || InStr(currTitle, "Instance")
+}
+
+else if(language == "uk_ua"){
+  return InStr(currTitle, "Гра наодинці") || InStr(currTitle, "Гра в мережі") || InStr(currTitle, "Instance")
+}
+
+else if(language == "zh_cn"){
+  return InStr(currTitle, "单人游戏") || InStr(currTitle, "多人游戏") || InStr(currTitle, "Instance")
+}
+
+else if(language == "zh_hk"){
+  return InStr(currTitle, "單人遊戲") || InStr(currTitle, "多人遊戲") || InStr(currTitle, "Instance")
+}
+
+else if(language == "zh_tw"){
+  return InStr(currTitle, "單人遊戲") || InStr(currTitle, "多人遊戲") || InStr(currTitle, "Instance")
+}
 
 else {
-  MsgBox, Language set incorrectly or not supported yet, please change it and restart script
+  MsgBox, Language not supported yet, please change it and restart script.
   ExitApp
 }
 


### PR DESCRIPTION
Adds English, LOLCAT, Shakespearean English, 日本語 (Japanese), Bosanski (Bosnian) and Nederlands (Dutch) support. I don't know if this is the best way to implement this and I also don't know how using a different language might affect ActivateSprintHitboxes or SeedInitialize because I can't figure out how to get those to work for me normally. This is probably not ready to merge but I'd like it to be looked over before I add more languages.